### PR TITLE
Simplify the unit test logic by using the plugins block instead

### DIFF
--- a/plugin/src/test/kotlin/org/gradleweaver/plugins/jlink/AbstractPluginTest.kt
+++ b/plugin/src/test/kotlin/org/gradleweaver/plugins/jlink/AbstractPluginTest.kt
@@ -23,6 +23,13 @@ abstract class AbstractPluginTest {
     val projectRoot: File
         get() = tempDir.toFile().resolve("plugin-test").apply { mkdirs() }
 
+    protected fun pluginsBlock() =
+        """
+        plugins {
+            id("org.gradleweaver.plugins.simple-jlink")
+        }
+        """.trimIndent()
+
     protected fun buildscriptBlockWithUnderTestPlugin() =
         """
         buildscript {
@@ -61,6 +68,7 @@ abstract class AbstractPluginTest {
             GradleRunner.create()
                     .withProjectDir(projectRoot)
                     .withArguments(arguments.toList())
+                    .withPluginClasspath()
 
     private
     val testRepositoryPath

--- a/plugin/src/test/kotlin/org/gradleweaver/plugins/jlink/JLinkPluginTest.kt
+++ b/plugin/src/test/kotlin/org/gradleweaver/plugins/jlink/JLinkPluginTest.kt
@@ -2,23 +2,20 @@ package org.gradleweaver.plugins.jlink
 
 import org.gradle.api.NamedDomainObjectCollection
 import org.gradle.testkit.runner.TaskOutcome
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.function.Executable
+import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
-class JLinkPluginTest: AbstractPluginTest() {
+class JLinkPluginTest : AbstractPluginTest() {
     @Test
     fun `can access the jlink extension`() {
         projectRoot.apply {
             buildKotlinFile().writeText(
                     """
-                ${buildscriptBlockWithUnderTestPlugin()}
-
-                ${pluginsBlockWithKotlinJvmPlugin()}
-
-                apply(plugin = "org.gradleweaver.plugins.simple-jlink")
+                ${pluginsBlock()}
 
                 // This extension should have been added by the accessor below.
                 jlink {
@@ -27,8 +24,6 @@ class JLinkPluginTest: AbstractPluginTest() {
                         assert(this is ${NamedDomainObjectCollection::class.qualifiedName}<*>)
                     }
                 }
-
-                ${kotlinExtensionAccessor()}
                 """.trimIndent()
             )
         }
@@ -44,11 +39,7 @@ class JLinkPluginTest: AbstractPluginTest() {
                     """
                 import org.gradleweaver.plugins.jlink.*
 
-                ${buildscriptBlockWithUnderTestPlugin()}
-
-                ${pluginsBlockWithKotlinJvmPlugin()}
-
-                apply(plugin = "org.gradleweaver.plugins.simple-jlink")
+                ${pluginsBlock()}
 
                 tasks.all {}
 
@@ -59,9 +50,7 @@ class JLinkPluginTest: AbstractPluginTest() {
                         modules = listOf("java.base") // To avoid calling jdeps on an empty file
                     }
                 }
-
-                ${kotlinExtensionAccessor()}
-                    """.trimIndent()
+                """.trimIndent()
             )
 
             resolve("test.jar").createNewFile()
@@ -88,7 +77,7 @@ class JLinkPluginTest: AbstractPluginTest() {
 
             // No changes were made to the jlink configuration or its input files
             // Make sure the task doesn't run unnecessarily
-            build (taskName).apply {
+            build(taskName).apply {
                 assertEquals(TaskOutcome.UP_TO_DATE, task(":$taskName")!!.outcome,
                         "The custom jlink task was not updated and should not have run")
             }
@@ -103,8 +92,8 @@ class JLinkPluginTest: AbstractPluginTest() {
     )
     fun `generated task names are correct`(configName: String, expectedJLinkTaskName: String, expectedJLinkZipTaskName: String) {
         assertAll(configName,
-                Executable { assertEquals(expectedJLinkTaskName, JLinkPlugin.generateJLinkTaskName(configName)) },
-                Executable { assertEquals(expectedJLinkZipTaskName, JLinkPlugin.generateJLinkArchiveTaskName(configName)) }
+                { assertEquals(expectedJLinkTaskName, JLinkPlugin.generateJLinkTaskName(configName)) },
+                { assertEquals(expectedJLinkZipTaskName, JLinkPlugin.generateJLinkArchiveTaskName(configName)) }
         )
     }
 


### PR DESCRIPTION
This significantly simplifies the tests by using the [GradleRunner.withPluginClassPath()](https://docs.gradle.org/current/javadoc/org/gradle/testkit/runner/GradleRunner.html#withPluginClasspath--) API as proposed in this github issue comment:
https://github.com/gradle/kotlin-dsl/issues/1178#issuecomment-429861533
