### PR TITLE
Include configuration name in compressed archive names

### DIFF
--- a/plugin/src/main/kotlin/org/gradleweaver/plugins/jlink/JLinkPlugin.kt
+++ b/plugin/src/main/kotlin/org/gradleweaver/plugins/jlink/JLinkPlugin.kt
@@ -66,11 +66,13 @@ open class JLinkPlugin : Plugin<Project> {
             group = JLINK_TASK_GROUP
             description = "Generates a .zip archive file of a native Java runtime image for '${options.name}'."
             from(project.tasks.getByName(jlinkTaskName).outputs)
+            archiveName = "${project.name}-${options.name.toLowerCase().replace(' ', '-')}.zip"
         }
         project.tasks.register(generateJLinkArchiveTaskName("Tar", options.name), Tar::class.java) {
             group = JLINK_TASK_GROUP
             description = "Generates a .tar.gz archive file of a native Java runtime image for '${options.name}'."
             from(project.tasks.getByName(jlinkTaskName).outputs)
+            archiveName = "${project.name}-${options.name.toLowerCase().replace(' ', '-')}.tar.gz"
             compression = Compression.GZIP
             extension = "tar.gz"
         }

--- a/plugin/src/main/kotlin/org/gradleweaver/plugins/jlink/JLinkPlugin.kt
+++ b/plugin/src/main/kotlin/org/gradleweaver/plugins/jlink/JLinkPlugin.kt
@@ -73,8 +73,6 @@ open class JLinkPlugin : Plugin<Project> {
             description = "Generates a .tar.gz archive file of a native Java runtime image for '${options.name}'."
             from(project.tasks.getByName(jlinkTaskName).outputs)
             baseName = "${project.name}-${options.name.toLowerCase().replace(' ', '-')}"
-            compression = Compression.GZIP
-            extension = "tar.gz"
         }
     }
 

--- a/plugin/src/main/kotlin/org/gradleweaver/plugins/jlink/JLinkPlugin.kt
+++ b/plugin/src/main/kotlin/org/gradleweaver/plugins/jlink/JLinkPlugin.kt
@@ -3,7 +3,6 @@ package org.gradleweaver.plugins.jlink
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.ApplicationPlugin
-import org.gradle.api.tasks.bundling.Compression
 import org.gradle.api.tasks.bundling.Tar
 import org.gradle.api.tasks.bundling.Zip
 import org.gradle.kotlin.dsl.create

--- a/plugin/src/main/kotlin/org/gradleweaver/plugins/jlink/JLinkPlugin.kt
+++ b/plugin/src/main/kotlin/org/gradleweaver/plugins/jlink/JLinkPlugin.kt
@@ -66,13 +66,13 @@ open class JLinkPlugin : Plugin<Project> {
             group = JLINK_TASK_GROUP
             description = "Generates a .zip archive file of a native Java runtime image for '${options.name}'."
             from(project.tasks.getByName(jlinkTaskName).outputs)
-            archiveName = "${project.name}-${options.name.toLowerCase().replace(' ', '-')}.zip"
+            baseName = "${project.name}-${options.name.toLowerCase().replace(' ', '-')}"
         }
         project.tasks.register(generateJLinkArchiveTaskName("Tar", options.name), Tar::class.java) {
             group = JLINK_TASK_GROUP
             description = "Generates a .tar.gz archive file of a native Java runtime image for '${options.name}'."
             from(project.tasks.getByName(jlinkTaskName).outputs)
-            archiveName = "${project.name}-${options.name.toLowerCase().replace(' ', '-')}.tar.gz"
+            baseName = "${project.name}-${options.name.toLowerCase().replace(' ', '-')}"
             compression = Compression.GZIP
             extension = "tar.gz"
         }


### PR DESCRIPTION
e.g. `javafx-app` will have `javafx-app-release-image.zip` instead of just `javafx-app.zip`, which would cause problems if images for multiple configurations are generated and zipped.