### PR TITLE
Move plugin namespace to org.gradleweaver

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ allprojects {
 
 project(":samples") {
     subprojects {
-        apply(plugin = "org.gradleweaver.plugins.simple-jlink")
+        apply(plugin = "org.gradleweaver.simple-jlink")
     }
 }
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -60,10 +60,11 @@ tasks.withType<Test>().configureEach {
     useJUnitPlatform()
 }
 
-val registeredPlugin = gradlePlugin.plugins.register("jlink-plugin") {
-    id = "${project.group}.${project.name}"
+val registeredPlugin = gradlePlugin.plugins.register("JLinkPlugin") {
+    id = "org.gradleweaver.simple-jlink"
+    displayName = "Simple JLink"
     implementationClass = "org.gradleweaver.plugins.jlink.JLinkPlugin"
-    description = "A Gradle plugin for handling platform-specific dependencies and releases."
+    description = "Generate native runtime images for your application with the JLink tool"
 }
 
 pluginBundle {
@@ -72,7 +73,7 @@ pluginBundle {
     tags = listOf("jlink")
 
     plugins {
-        create("jlink-plugin") {
+        create("JLinkPlugin") {
             id = registeredPlugin.get().id
             displayName = registeredPlugin.get().displayName
         }

--- a/plugin/src/test/kotlin/org/gradleweaver/plugins/jlink/AbstractPluginTest.kt
+++ b/plugin/src/test/kotlin/org/gradleweaver/plugins/jlink/AbstractPluginTest.kt
@@ -26,7 +26,7 @@ abstract class AbstractPluginTest {
     protected fun pluginsBlock() =
         """
         plugins {
-            id("org.gradleweaver.plugins.simple-jlink")
+            id("org.gradleweaver.simple-jlink")
         }
         """.trimIndent()
 


### PR DESCRIPTION
Change "jlink-plugin" to "JLinkPlugin" so publishing tasks have saner names
Tweak plugin description a bit
